### PR TITLE
Fix login menu and key length

### DIFF
--- a/PasswordEncryption/Feistel Cipher/main.py
+++ b/PasswordEncryption/Feistel Cipher/main.py
@@ -30,7 +30,8 @@ class feistel:
         print(self.R1, self.L1)
         
     def generateKey(self):  #generate a random key using secrets library
-        length = len(self.L1) * 8   #set length to 8 times size of halves (each letter is 8 bits)
+        # keys should match the size of the first half
+        length = len(self.R1) * 8   # set length to 8 times size of halves (each letter is 8 bits)
         self.K1 = f'{secrets.randbits(length):0{length}b}'  #format randbits to n length binary values where n is size of halves in bits
         self.K2 = f'{secrets.randbits(length):0{length}b}'
         print(self.K1, self.K2)

--- a/PasswordEncryption/UserPasswordSystem/UserPassSystem.py
+++ b/PasswordEncryption/UserPasswordSystem/UserPassSystem.py
@@ -12,7 +12,7 @@ class passwordSystem:
              # ^check key in data         ^check value attatched to key 
 class userMenu:
     def __init__(self):
-        self.obj = passwordSystem() #constructor method, instantiates passwordSysten
+        self.obj = passwordSystem()  # constructor method, instantiates passwordSystem
     
     def menu(self):
         setFlag = '0' #flag for resetting user/pass prompt
@@ -21,7 +21,7 @@ class userMenu:
                 choice = input("Create Account(1) or Login(2)?\n")
             if choice == '1':
                 username = input("Create a Username: ")
-                password = input("Create a assword: ")
+                password = input("Create a Password: ")
                 self.obj.mapCreate(username, password)
                 print(f"{username}'s account created")
                 
@@ -34,7 +34,7 @@ class userMenu:
                 else:
                     print("Incorrect username or password")
                     setFlag = '1'
-            elif choice == 3:
+            elif choice == '3':
                 print("Exiting...")
                 break
             else:


### PR DESCRIPTION
## Summary
- fix missing password text and proper exit handling
- adjust Feistel key generation to use size of first half

## Testing
- `python -m py_compile 'PasswordEncryption/Feistel Cipher/main.py' PasswordEncryption/UserPasswordSystem/UserPassSystem.py`

------
https://chatgpt.com/codex/tasks/task_e_68408299e508832996d7d8d4217d41ff